### PR TITLE
Initial docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
 # CHIP 3.7: Wordguesser: a scaffolded (!) ESaaS getting-started assignment
 
-
 (v1.1, September 2015.  Written by Armando Fox and Nick Herson)
 (some edits by mverdicchio 21 September 2015)
-(refinements by Armando Fox September 2017)
+(refinements by Armando Fox, September 2017)
+(modified by Peter DePasquale, February 2026)
 
-In this assignment you'll be introduced to part of the basic cycle of creating SaaS in a disciplined way.
+In this assignment, you'll be introduced to part of the basic cycle of creating SaaS in a disciplined way.
 
-**NOTE: Do not clone this repo to your workspace. Fork it first, then clone your fork.**
-
-
+**NOTE: Before you begin, we need to "copy" this repo from this account to your GitHub account. When looking at the repo in GitHub, use the "Use this template" button and select the "Create a new repository" option. In the window that appears, ensure that the resulting copied repo will be in your account, and you should use the same name as this repo: hw-sinatra-saas-wordguesser. Provide a description if you like, but select the visibility to be Private. Then, on your local machine, clone your repo and do your work there on your local machine.**
 
 Learning Goals
 --------------
@@ -23,22 +21,22 @@ After completing this assignment, you will be able to:
 
 Prerequisites
 -------------
-* You should be familiar with Ruby basics, for example by completing the Ruby Intro or Ruby Calisthenics assignment.
-* You should have read [ESaaS](http://www.saasbook.info) Chapter 2, "The Architecture of SaaS Applications", and watched the accompanying videos in the [MOOC](http://www.saas-class.org).
-* You should be comfortable with basic Git usage and how to push your code to GitHub, as described in Appendix A of [ESaaS](http://www.saasbook.info).
+* You should be familiar with Ruby basics, for example, by completing the Ruby Intro or Ruby Calisthenics assignment (CHIP 2.5)
+* You should have read [ESaaS](http://www.saasbook.info) Chapter 2, "The Architecture of SaaS Applications".
+* You should be comfortable with basic Git usage and how to push your code to GitHub.
 * You will need "survival level" Unix command-line skills and facility with an editor to edit code files.
 
 **NOTE: You may find the [Sinatra documentation](https://sinatrarb.com) helpful to have on hand.**
 
 Introduction
 ------------
-The full Agile/XP cycle we follow in ESaaS includes talking to the customer, using BDD to develop scenarios, turning those scenarios into runnable integration/acceptance tests with Cucumber, using those scenarios plus TDD to drive the creation of actual code, and deploying the result of each iteration's work to the cloud.
+The full Agile/XP cycle we follow in ESaaS includes talking to the customer, using BDD to develop scenarios, turning those scenarios into runnable integration/acceptance tests with [Cucumber](https://cucumber.io/), using those scenarios plus TDD to drive the creation of actual code, and deploying the result of each iteration's work to the cloud.
 
-In this introductory assignment, we've provided RSpec unit tests to let you use TDD to develop game logic for a word-guessing game.  In the full Agile/XP cycle, you'd develop these tests yourself as you code.
+In this introductory assignment, we've provided [RSpec](https://rspec.info/) unit tests to let you use TDD to develop game logic for a word-guessing game. In the full Agile/XP cycle, you'd develop these tests yourself as you code.
 
-You'll then use the Sinatra framework to make the Wordguesser game available as SaaS. Adapting the game logic for SaaS will introduce you to thinking about RESTful routes and service-oriented architecture. As you develop the "SaaS-ified" Wordguessing game, you'll use Cucumber to describe how gameplay will work from the player's point of view and as "full stack" integration tests that will drive SaaS development.  In the full Agile/XP cycle, you'd develop Cucumber scenarios yourself based on consultation with the customer, and create the necessary *step definitions* (Cucumber code that turns plain-English scenarios into runnable tests).  In this assignment we provide both the scenarios and step definitions for you.
+You'll then use the Sinatra framework to make the Wordguesser game available as SaaS. Adapting the game logic for SaaS will introduce you to thinking about RESTful routes and service-oriented architecture. As you develop the "SaaS-ified" Wordguessing game, you'll use Cucumber to describe how gameplay will work from the player's point of view and as "full stack" integration tests that will drive SaaS development.  In the full Agile/XP cycle, you'd develop Cucumber scenarios yourself based on consultation with the customer, and create the necessary *step definitions* (Cucumber code that turns plain-English scenarios into runnable tests). In this assignment, we provide both the scenarios and step definitions for you.
 
-You'll deploy your game to the cloud using Heroku, giving you experience in automating SaaS deployment.
+You'll deploy your game to the cloud using [Heroku](https://www.heroku.com/), giving you experience in automating SaaS deployment.
 
 **Why Sinatra?**
 

--- a/docs/part_0_create_saas_app.md
+++ b/docs/part_0_create_saas_app.md
@@ -22,16 +22,16 @@ Let's start with the following steps:
 
 ```rb
 source 'https://rubygems.org'
-ruby '2.6.6'
+ruby  '3.3.8'
 
-gem 'sinatra', '>= 2.0.1'
+gem 'sinatra', '~> 4.0'
 ```
 
-The first line says that the preferred place to download any necessary gems is https://rubygems.org, which is where the Ruby community registers "production ready" gems.
+The first line says that the preferred place to download any necessary gems is https://rubygems.org, which is where the Ruby community registers "production-ready" gems.
 
 The second line specifies which version of the Ruby language interpreter is required.  If we omitted this line, Bundler wouldn't try to verify which version of Ruby is available; there are subtle differences between the versions, and not all gems work with all versions, so it's best to specify this.
 
-The last line says we need version 2.0.1 or later of the `sinatra` gem. In some cases we don't need to specify which version of a gem we want; in this case we do specify it because we rely on some features that are absent from earlier versions of Sinatra.
+The last line says we need version 4.0 or later of the `sinatra` gem. In some cases, we don't need to specify which version of a gem we want; in this case, we do specify it because we rely on some features that are absent from earlier versions of Sinatra.
 
 Run Bundler
 -----------
@@ -45,7 +45,7 @@ $ git add .
 $ git commit -m "Set up the Gemfile"
 ```
 
-The first command stages all changed files for committing. The second command commits the staged files with the comment in the quotes. You can repeat these commands to commit future changes. Remember that these are LOCAL commits -- if you want these changes on GitHub, you'll need to do a git push command, which we will show later.
+The first command stages all changed files for committing. The second command commits the staged files with the comment in the quotes. You can repeat these commands to commit future changes. Remember that these are LOCAL commits -- if you want these changes on GitHub, you'll need to do a `git push` command, which we will show later.
 
 #### Self Check Questions (click triangle to check your answer)
 
@@ -60,11 +60,10 @@ that were not listed in <code>Gemfile</code>?</summary>
   <p><blockquote>Bundler looked up the information for each Gem you requested (in this case, only <code>sinatra</code>) and realized that it depends on other gems, which in turn depend on still others, so it recursively installed all those dependencies.  For example, the <code>rack</code> appserver is a gem, and while you didn't explicitly request it, <code>sinatra</code> depends on it.  This is an example of the power of automation: rather than requiring you (the app developer) to understand every Gem dependency, Bundler automates that process and lets you focus only on your app's top-level dependencies.</blockquote></p>
 </details>
 
-
 Create a simple SaaS app with Sinatra
 -------------------------------------
 
-As Chapter 2 of ESaaS explains, SaaS apps require a web server to receive HTTP requests from the outside world, and an application server that "connects" your app's logic to the web server.  For development, we will use `webrick`, a very simple Ruby-based web server that would be inappropriate for production but is fine for development.  In both development and production, we will use the `rack` Ruby-based application server, which supports Ruby apps written in various frameworks including Sinatra and Rails.
+As Chapter 2 of ESaaS explains, SaaS apps require a web server to receive HTTP requests from the outside world, and an application server that "connects" your app's logic to the web server. For development, we will use `webrick`, a very simple Ruby-based web server that would be inappropriate for production but is fine for development.  In both development and production, we will use the `rack` Ruby-based application server, which supports Ruby apps written in various frameworks, including Sinatra and Rails.
 
 As Chapter 2 of *ESaaS* explains, a SaaS app essentially recognizes and responds to HTTP requests corresponding to the application's *routes* (recall that a route consists of an HTTP method such as `GET` or `POST` plus a URI).  Sinatra provides an extremely lightweight shorthand for matching a route with the app code to be executed when a request using that route arrives from the Web server.
 
@@ -88,7 +87,6 @@ The `get` method is provided by the `Sinatra::Base` class, from which our `MyApp
   <summary>What *two* steps did we take earlier to guarantee that the Sinatra library is available to load in line 1?</summary>
   <p><blockquote> We specified <code>gem 'sinatra'</code> in the <code>Gemfile</code> *and* successfully ran <code>bundle</code> to confirm that the gem is installed and "lock" the correct version of it in <code>Gemfile.lock</code>.</blockquote></p>
 </details>
-
 <br />
 
 As you see from the above simple example, Sinatra lets you write functions that match an incoming HTTP route, in this case `GET '/'` (the root URL), a very simple HTML document containing the string `Hello World` will be returned to the presentation tier as the result of the request.
@@ -100,20 +98,13 @@ require './app'
 run MyApp
 ```
 
-The first line tells Rack that our app lives in the file `app.rb`, which you created above to hold your app's code.  We have to explicitly state that our `app` file is located in the current directory (.) because `require` normally looks only in standard system directories to find gems.
+The first line tells Rack that our app lives in the file `app.rb`, which you created above to hold your app's code.  We have to explicitly state that our `app` file is located in the current directory (`.`) because `require` normally looks only in standard system directories to find gems.
 
-You're now ready to test-drive our simple app with a command line:
-| Local computer | Codio |
-|-----|------|
-| `bundle exec rackup --port 3000` | `bundle exec rackup --host 0.0.0.0 --port 3000` |
+You're now ready to test-drive our simple app with a command line: `bundle exec rackup --port 3000`
 
 This command starts the Rack appserver and the WEBrick webserver.  Prefixing it with `bundle exec` ensures that you are running with the gems specified in `Gemfile.lock`.  Rack will look for `config.ru` and attempt to start our app based on the information there.
 
-To see the webapp:
-
-| Local computer | Codio |
-|-----|------|
-| Visit `localhost:3000` in your browser to see the webapp. It will open in a new tab in the IDE if you click on it, but you should open up a fresh browser tab and paste in that URL. <br><br> Point a new Web browser tab at the running app's URL and verify that you can see "Hello World". | Click the "Box URL" button on your top tool bar. The button should be pre-configured to point at port 3000: <br> <br> ![BoxURL](https://global.codio.com/content/BoxURL.png) <br> <br> The app should open in a new tab. Verify that you can see "Hello World". |
+To see the webapp: Visit `localhost:3000` in your browser to see the webapp. It will open in a new tab in the IDE if you click on it, but you should open up a fresh browser tab and paste in that URL. <br><br> Point a new Web browser tab at the running app's URL and verify that you can see "Hello World".
 
 #### Self Check Question
 
@@ -124,7 +115,7 @@ To see the webapp:
 
 <br />
 
-You should now have the following files under version control: `Gemfile`, `Gemfile.lock`, `app.rb`, `config.ru`.  This is a minimal SaaS app: the app file itself, the list of explicitly required gems, the list of actual gems installed including the dependencies implied by the required gems, and a configuration file telling the appserver how to start the app.
+You should now have the following files under version control: `Gemfile`, `Gemfile.lock`, `app.rb`, `config.ru`.  This is a minimal SaaS app: the app file itself, the list of explicitly required gems, the list of actual gems installed, including the dependencies implied by the required gems, and a configuration file telling the appserver how to start the app.
 
 Modify the app
 --------------
@@ -133,7 +124,7 @@ Modify `app.rb` so that instead of "Hello World" it prints "Goodbye World". Save
 
 No changes? Confused?
 
-Now go back to the shell window where you ran `rackup` and press Ctrl-C to stop Rack.  Then type `bundle exec rackup --port 3000` for local development or `$bundle exec rackup --host 0.0.0.0 --port 3000` for Codio development again, and once it is running, go back to your browser tab with your app and refresh the page.  This time it should work.
+Now go back to the shell window where you ran `rackup` and press Ctrl-C to stop Rack.  Then type `bundle exec rackup --port 3000` for local development, and once it is running, go back to your browser tab with your app and refresh the page.  This time it should work.
 
 What this shows you is that if you modify your app while it's running, you have to restart Rack in order for it to "see" those changes.  Since restarting it manually is tedious, we'll use the `rerun` gem, which restarts Rack automatically when it sees changes to files in the app's directory. (Rails does this for you by default during development, as we'll see, but Sinatra doesn't.)
 
@@ -147,34 +138,31 @@ end
 
 Now run `bundle install` to have it download the `rerun` gem and any dependencies, if they aren't already in place.
 
-Any gem specifications inside the `group :development` block will only be examined if bundle is run in the development environment.  (The other environments you can specify are :test and :production, and you can define new environments yourself.)  Gem specifications outside of any group block are assumed to apply in all environments.
+Any gem specifications inside the `group :development` block will only be examined if bundle is run in the development environment.  (The other environments you can specify are `:test` and `:production`, and you can define new environments yourself.)  Gem specifications outside of any group block are assumed to apply in all environments.
 
-Say the following in the terminal window to start your app and verify the app is running:
-| Local computer | Codio |
-|-----|------|
-| `bundle exec rerun -- rackup --port 3000` | `bundle exec rerun -- rackup -p 3000 -o 0.0.0.0` |
+Say the following in the terminal window to start your app and verify the app is running: `bundle exec rerun -- rackup --port 3000`
 
 There are more details on rerun's usage available in the gem's [GitHub
 README](https://github.com/alexch/rerun#usage). Gems are usually on
 GitHub and their READMEs are usually full of helpful instructions about how to use them.
 
-In this case we are prefixing with `bundle exec` again in order to ensure we are using the gems in the Gemfile.lock, and the `--` symbol is there to assert that the command we want rerun to operate with is `rackup -p $PORT -o $IP`.  We could achieve the same effect with `bundle exec rerun "rackup -p 3000 -o 0.0.0.0"`.  They are equivalent.   More importantly, any detected changes will now cause the server to restart automatically, similar to the use of `guard` to auto re-run specs when files change.
+In this case, we are prefixing with `bundle exec` again in order to ensure we are using the gems in the Gemfile.lock, and the `--` symbol is there to assert that the command we want rerun to operate with is `rackup -p $PORT -o $IP`.  We could achieve the same effect with `bundle exec rerun "rackup -p 3000 -o 0.0.0.0"`.  They are equivalent.   More importantly, any detected changes will now cause the server to restart automatically, similar to the use of `guard` to auto re-run specs when files change.
 
-Modify `app.rb` to print a different message, and verify that the change is detected by refreshing your browser tab with the running app.  Also before we move on you should commit your latest changes to git.
+Modify `app.rb` to print a different message, and verify that the change is detected by refreshing your browser tab with the running app.  Also, before we move on, you should commit your latest changes to git.
 
 Deploy to Heroku
 ----------------
-Heroku is a cloud platform-as-a-service (PaaS) where we can deploy our Sinatra (and later Rails) applications. If you don't have an account yet, go sign up at http://www.heroku.com. You'll need your login and password for the next step.
+Heroku is a cloud [platform-as-a-service](https://en.wikipedia.org/wiki/Platform_as_a_service) (PaaS) where we can deploy our Sinatra (and later Rails) applications. If you don't have an account yet, go sign up at http://www.heroku.com. You'll need your login and password for the next step.
 
-Install Heroku CLI following [instructions](https://devcenter.heroku.com/articles/heroku-cli).
+Install Heroku CLI following their [instructions](https://devcenter.heroku.com/articles/heroku-cli).
 
-Log in to your Heroku account by typing the command: `heroku login -i` in the terminal. This will connect you to your Heroku account.
+Log in to your Heroku account by typing the command: `heroku login -i` in the terminal. This will connect you to your Heroku account.  (**Note: ​​You can’t use the `-i` option if you have multi-factor authentication enabled due to a technical dependency on web browsers for verification.)
 
 While in the root directory of your project (not your whole workspace), type `heroku create` to create a new project in Heroku. This will tell the Heroku service to prepare for some incoming code, and locally it will add a remote git repository for you called `heroku`.
 
-Next, make sure you stage and commit all changes locally as instructed above (i.e. `git add`, `git commit`, etc).
+Next, make sure you stage and commit all changes locally as instructed above (i.e., `git add`, `git commit`, etc).
 
-Earlier we saw that to run the app locally you run `rackup` to start the Rack appserver, and Rack looks in `config.ru` to determine how to start your Sinatra app.  How do you tell a production environment how to start an appserver or other processes necessary to receive requests and start your app?  In the case of Heroku, this is done with a special file named `Procfile`,  which specifies one or more types of Heroku processes your app will use, and how to start each one. The most basic Heroku process type is called a Dyno, or "web worker".  One Dyno can serve one user request at a time.  Since we're on Heroku's free tier, we can only have one Dyno. Let's create a file named `Procfile`, and only this as the name (i.e. Procfile.txt is not valid). Write the following line in your `Procfile`:
+Earlier, we saw that to run the app locally you run `rackup` to start the Rack appserver, and Rack looks in `config.ru` to determine how to start your Sinatra app.  How do you tell a production environment how to start an appserver or other processes necessary to receive requests and start your app?  In the case of Heroku, this is done with a special file named `Procfile`,  which specifies one or more types of Heroku processes your app will use, and how to start each one. The most basic Heroku process type is called a Dyno, or "web worker".  One Dyno can serve one user request at a time.  Since we're on Heroku's free tier, we can only have one Dyno. Let's create a file named `Procfile`, and only this as the name (i.e. Procfile.txt is not valid). Write the following line in your `Procfile`:
 
 ```
 web: bundle exec rackup config.ru -p $PORT

--- a/docs/part_7_optional_challenge.md
+++ b/docs/part_7_optional_challenge.md
@@ -1,24 +1,26 @@
-# Optional challenge assignment
+# Optional challenge assignment (OUTDATED)
 
+~Verify that a file exists in the courseware VM called `/usr/share/dict/words`.  What's in it?~
 
-Verify that a file exists in the courseware VM called `/usr/share/dict/words`.  What's in it?
+~(Note: if this file doesn't exist, you can install it on Ubuntu 14 by typing `sudo apt-get install --reinstall wamerican`.~
+~On other distributions or non-Linux versions of Unix, the file may be~
+~[elsewhere](http://objectroot.org/articles/brief-history-of-hier/), or absent.~
 
-(Note: if this file doesn't exist, you can install it on Ubuntu 14 by typing `sudo apt-get install --reinstall wamerican`.  On other distributions or non-Linux versions of Unix, the file may be  [elsewhere](http://objectroot.org/articles/brief-history-of-hier/), or absent. 
+~> This file has been part of Unix since almost~
+~> [the beginning of time](http://en.wikipedia.org/wiki/Unix_time).~
+~> It has been used by programs ranging from spelling~
+~> checkers to password guessers.~
 
-> This file has been part of Unix since almost 
-> [the beginning of time](http://en.wikipedia.org/wiki/Unix_time).
-> It has been used by programs ranging from spelling
-> checkers to password guessers.
+~<details>~
+~<summary>Why do you think we used a remote SOA endpoint to generate random words for Wordguesser rather than~
+~<code>/usr/share/dict/words</code>?  (Hint: It's not simply to give you an initial taste of using SOA.)</summary>~
+~<p><blockquote>In many hosted deployment environments, you cannot rely on the~
+~presence of the local filesystem, and in shared environments such as~
+~Heroku you may not have access to the filesystem at all.  All state~
+~must be stored in managed storage such as a database or other per-app~
+~abstraction, or managed on remote servers.~
+~</blockquote></p>~
+~</details>~
+~<br/>~
 
-<details>
-<summary>Why do you think we used a remote SOA endpoint to generate random words for Wordguesser rather than <code>/usr/share/dict/words</code>?  (Hint: It's not simply to give you an initial taste of using SOA.)</summary>
-<p><blockquote>In many hosted deployment environments, you cannot rely on the
-presence of the local filesystem, and in shared environments such as
-Heroku you may not have access to the filesystem at all.  All state
-must be stored in managed storage such as a database or other per-app
-abstraction, or managed on remote servers.
-</blockquote></p>
-</details>
-<br/>
-
-Using Sinatra, create and deploy locally (on your computer) a *SOA endpoint* that mimics the behavior of the Random Word Generator service we used in this assignment.  A simple implementation would respond to the RESTful request `GET /` with a random word drawn randomly from `/usr/share/dict/words`. 
+~Using Sinatra, create and deploy locally (on your computer) a *SOA endpoint* that mimics the behavior of the Random Word Generator service we used in this assignment.  A simple implementation would respond to the RESTful request `GET /` with a random word drawn randomly from `/usr/share/dict/words`.~


### PR DESCRIPTION
This does not work as we wish....

Students should use this to build a Docker image as: 

` docker build -t hw-sinatra-saas-wordguesser:latest .`

And then can run it and use the shell to issue commands:

`docker run -p 3000:3000 -it hw-sinatra-saas-wordguesser /bin/bash`

Once in the shell, they would need to do the `bundle install` so that the gems are installed (it's good practice to learn this since they didn't do it in CHIP 2.5).  Next, they would need to run the server:

`bundle exec rackup --port 3000 &` (let's debug this with the webapp server in the background and return to the shell...)

I then tried to confirm the server is responding:
```bash
root@055681cbd1d1:/app# bundle exec rackup --port 3000 &
[1] 482
root@055681cbd1d1:/app# Puma starting in single mode...
* Puma version: 6.6.1 ("Return to Forever")
* Ruby version: ruby 3.3.8 (2025-04-09 revision b200bad6cd) [aarch64-linux]
*  Min threads: 0
*  Max threads: 5
*  Environment: development
*          PID: 482
* Listening on http://127.0.0.1:3000
* Listening on http://[::1]:3000
Use Ctrl-C to stop

root@055681cbd1d1:/app# curl localhost:3000
127.0.0.1 - - [02/Feb/2026:20:20:46 +0000] "GET / HTTP/1.1" 302 - 0.0067
root@055681cbd1d1:/app# curl 127.0.0.1:3000
127.0.0.1 - - [02/Feb/2026:20:20:52 +0000] "GET / HTTP/1.1" 302 - 0.0018
```

Things that confuse me (and maybe this leads to the problem?). In [Part 0 of the docs](docs/part_0_create_saas_app.md), it talks about using `webrick` in development and then `rack` in production. What server did I just start, since I see an output reference to `Puma`!